### PR TITLE
Store PHP sessions in Redis

### DIFF
--- a/nested/vmsetupparams.json
+++ b/nested/vmsetupparams.json
@@ -40,6 +40,7 @@
             "lampProfile": {
                 "storageAccountName": "[parameters('lampCommon').storageAccountName]",
                 "storageAccountKey": "[parameters('storageAccountKey')]",
+                "redisDeploySwitch": "[parameters('lampCommon').redisDeploySwitch]",
                 "redisDns": "[parameters('lampCommon').redisDns]",
                 "redisKey": "[parameters('redisKey')]",
                 "syslogServer": "[parameters('lampCommon').ctlrVmName]",

--- a/scripts/helper_functions.sh
+++ b/scripts/helper_functions.sh
@@ -31,6 +31,7 @@ function get_setup_params_from_configs_json
     export dbadminpass=$(echo $json | jq -r .dbServerProfile.adminPassword)
     export storageAccountName=$(echo $json | jq -r .lampProfile.storageAccountName)
     export storageAccountKey=$(echo $json | jq -r .lampProfile.storageAccountKey)
+    export redisDeploySwitch=$(echo $json | jq -r .lampProfile.redisDeploySwitch)
     export redisDns=$(echo $json | jq -r .lampProfile.redisDns)
     export redisAuth=$(echo $json | jq -r .lampProfile.redisKey)
     export dbServerType=$(echo $json | jq -r .dbServerProfile.type)

--- a/scripts/setup_controller.sh
+++ b/scripts/setup_controller.sh
@@ -41,6 +41,7 @@ set -ex
     echo $dbadminpass          >> /tmp/vars.txt
     echo $storageAccountName   >> /tmp/vars.txt
     echo $storageAccountKey    >> /tmp/vars.txt
+    echo $redisDeploySwitch    >> /tmp/vars.txt
     echo $redisDns             >> /tmp/vars.txt
     echo $redisAuth            >> /tmp/vars.txt
     echo $dbServerType                >> /tmp/vars.txt

--- a/scripts/setup_webserver.sh
+++ b/scripts/setup_webserver.sh
@@ -28,18 +28,21 @@ lamp_on_azure_configs_json_path=${1}
 
 get_setup_params_from_configs_json $lamp_on_azure_configs_json_path || exit 99
 
-echo $glusterNode    >> /tmp/vars.txt
-echo $glusterVolume  >> /tmp/vars.txt
-echo $siteFQDN >> /tmp/vars.txt
-echo $httpsTermination >> /tmp/vars.txt
-echo $syslogServer >> /tmp/vars.txt
-echo $dbServerType >> /tmp/vars.txt
-echo $fileServerType >> /tmp/vars.txt
-echo $storageAccountName >> /tmp/vars.txt
-echo $storageAccountKey >> /tmp/vars.txt
-echo $nfsVmName >> /tmp/vars.txt
-echo $nfsByoIpExportPath >> /tmp/vars.txt
+echo $glusterNode         >> /tmp/vars.txt
+echo $glusterVolume       >> /tmp/vars.txt
+echo $siteFQDN            >> /tmp/vars.txt
+echo $httpsTermination    >> /tmp/vars.txt
+echo $syslogServer        >> /tmp/vars.txt
+echo $dbServerType        >> /tmp/vars.txt
+echo $fileServerType      >> /tmp/vars.txt
+echo $storageAccountName  >> /tmp/vars.txt
+echo $storageAccountKey   >> /tmp/vars.txt
+echo $nfsVmName           >> /tmp/vars.txt
+echo $nfsByoIpExportPath  >> /tmp/vars.txt
 echo $htmlLocalCopySwitch >> /tmp/vars.txt
+echo $redisDeploySwitch   >> /tmp/vars.txt
+echo $redisDns            >> /tmp/vars.txt
+echo $redisAuth           >> /tmp/vars.txt
 
 check_fileServerType_param $fileServerType
 
@@ -180,6 +183,11 @@ EOF
   sed -i "s/;opcache.enable.*/opcache.enable = 1/" $PhpIni
   sed -i "s/;opcache.memory_consumption.*/opcache.memory_consumption = 256/" $PhpIni
   sed -i "s/;opcache.max_accelerated_files.*/opcache.max_accelerated_files = 8000/" $PhpIni
+  # Redis for sessions
+  if [ "$redisDeploySwitch" = "true" ]; then
+    sed -i "s/session.save_handler.*/session.save_handler = redis/" $PhpIni
+    sed -i "s/;session.save_path.*/session.save_path = \"tcp://$redisDns:6379?auth=$redisAuth\"/" $PhpIni
+  fi
     
   # Remove the default nginx site
   rm -f /etc/nginx/sites-enabled/default

--- a/scripts/setup_webserver.sh
+++ b/scripts/setup_webserver.sh
@@ -186,7 +186,7 @@ EOF
   # Redis for sessions
   if [ "$redisDeploySwitch" = "true" ]; then
     sed -i "s/session.save_handler.*/session.save_handler = redis/" $PhpIni
-    sed -i "s/;session.save_path.*/session.save_path = \"tcp://$redisDns:6379?auth=$redisAuth\"/" $PhpIni
+    sed -i "s/;session.save_path.*/session.save_path = \"tcp:\/\/$redisDns:6379?auth=$redisAuth\"/" $PhpIni
   fi
     
   # Remove the default nginx site


### PR DESCRIPTION
If Redis is enabled, configure the web server's php.ini to store the sessions inside Redis, so they're available to all nodes.

This is helpful for apps that are using PHP's builtin sessions.