### PR TITLE
Removed duplicate parameter 'fileServerDiskStorageType' and fix MySQL 'DB Azure Admin' name.

### DIFF
--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -380,17 +380,6 @@
             },
             "type": "int"
         },
-        "fileServerDiskStorageType": {
-            "type": "string",
-            "defaultValue": "Premium_LRS",
-            "allowedValues": [
-                "Premium_LRS",
-                "Standard_LRS"
-            ],
-            "metadata": {
-                "description": "Azure storage type for Disks created for nfs/azurefiles/gluster file server."
-            }
-        },
         "fileServerDiskCount": {
             "defaultValue": 4,
             "minValue": 2,
@@ -978,7 +967,7 @@
                         "value": "[parameters('fileServerDiskSize')]"
                     },
                     "dataDiskStorageType": {
-                        "value": "[parameters('fileServerDiskStorageType')]"
+                        "value": "[parameters('storageAccountType')]"
                     },
                     "resourcesUniqueString": {
                         "value": "[variables('resourceprefix')]"
@@ -1351,7 +1340,6 @@
             "extProbeHTTPS": "[concat('lb-probe-https-',variables('resourceprefix'))]",
             "fileServerDiskCount": "[parameters('fileServerDiskCount')]",
             "fileServerDiskSize": "[parameters('fileServerDiskSize')]",
-            "fileServerDiskStorageType": "[parameters('fileServerDiskStorageType')]",
             "OSDiskSizeInGB": "[parameters('OSDiskSizeInGB')]",
             "fileServerType": "[parameters('fileServerType')]",
             "fileServerVmCount": 2,

--- a/nested/controller.json
+++ b/nested/controller.json
@@ -216,7 +216,7 @@
                 "count": 8,
                 "input": {
                     "managedDisk": {
-                        "storageAccountType": "[parameters('lampCommon').fileServerDiskStorageType]"
+                        "storageAccountType": "[parameters('lampCommon').storageAccountType]"
                     },
                     "diskSizeGB": "[parameters('lampCommon').fileServerDiskSize]",
                     "lun": "[copyIndex('nfsDiskArray')]",

--- a/nested/glustervm.json
+++ b/nested/glustervm.json
@@ -97,7 +97,7 @@
                             "count": "[parameters('lampCommon').fileServerDiskCount]",
                             "input": {
                                 "managedDisk": {
-                                    "storageAccountType": "[parameters('lampCommon').fileServerDiskStorageType]"
+                                    "storageAccountType": "[parameters('lampCommon').storageAccountType]"
                                 },
                                 "diskSizeGB": "[parameters('lampCommon').fileServerDiskSize]",
                                 "lun": "[copyIndex('dataDisks')]",

--- a/nested/vmsetupparams.json
+++ b/nested/vmsetupparams.json
@@ -57,7 +57,7 @@
                 "type": "[parameters('lampCommon').dbServerType]",
                 "fqdn": "[parameters('dbFQDN')]",
                 "adminLogin": "[parameters('lampCommon').dbLogin]",
-                "adminLoginAzure": "[concat(parameters('lampCommon').dbLogin, '@', parameters('lampCommon').dbServerType, '-', parameters('lampCommon').resourcesPrefix)]",
+                "adminLoginAzure": "[concat(parameters('lampCommon').dbLogin, '@', parameters('lampCommon').serverName)]",
                 "adminPassword": "[parameters('lampCommon').dbLoginPassword]",
                 "mssqlDbServiceObjectiveName": "[parameters('lampCommon').mssqlDbServiceObjectiveName]",
                 "mssqlDbEdition": "[parameters('lampCommon').mssqlDbEdition]",


### PR DESCRIPTION
In one of the recent, I accidentally introduced duplicate parameter called 'fileServerDiskStorageType'. Instead, already existing 'storageAccountType' parameter should be used across the ARM Templates.