### PR TITLE
Fix for 'Unable to acquire the dpkg frontend lock'

### DIFF
--- a/scripts/helper_functions.sh
+++ b/scripts/helper_functions.sh
@@ -6,7 +6,7 @@
 function wait_for_apt_lock
 {
     while sudo fuser /var/lib/dpkg/lock-frontend /var/lib/dpkg/lock /var/lib/apt/lists/lock /var/cache/apt/archives/lock /var/lib/apt/daily_lock >/dev/null 2>&1; do 
-        echo 'Waiting for release of dpkg/apt locks';
+        echo "`date`: waiting for release of dpkg/apt locks" >> /tmp/frontend-lock.log
         sleep 10;
     done;
 }

--- a/scripts/helper_functions.sh
+++ b/scripts/helper_functions.sh
@@ -2,6 +2,15 @@
 
 # Common functions definitions
 
+# waits for apt locks to be released
+function wait_for_apt_lock
+{
+    while sudo fuser /var/lib/dpkg/lock-frontend /var/lib/dpkg/lock /var/lib/apt/lists/lock /var/cache/apt/archives/lock /var/lib/apt/daily_lock >/dev/null 2>&1; do 
+        echo 'Waiting for release of dpkg/apt locks';
+        sleep 10;
+    done;
+}
+
 function get_setup_params_from_configs_json
 {
     local configs_json_path=${1}    # E.g., /var/lib/cloud/instance/lamp_on_azure_configs.json
@@ -259,7 +268,9 @@ function install_php_mssql_driver
     # Download and build php/mssql driver
     /usr/bin/curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
     /usr/bin/curl https://packages.microsoft.com/config/ubuntu/16.04/prod.list > /etc/apt/sources.list.d/mssql-release.list
+    wait_for_apt_lock
     sudo apt-get update
+    wait_for_apt_lock
     sudo ACCEPT_EULA=Y apt-get install msodbcsql mssql-tools unixodbc-dev -y
     echo 'export PATH="$PATH:/opt/mssql-tools/bin"' >> ~/.bash_profile
     echo 'export PATH="$PATH:/opt/mssql-tools/bin"' >> ~/.bashrc
@@ -387,6 +398,7 @@ function create_raid0_ubuntu {
     if [ $_RET -eq 1 ];
     then 
         echo "installing mdadm"
+        wait_for_apt_lock
         sudo apt-get -y -q install mdadm
     fi
     echo "Creating raid0"
@@ -494,6 +506,7 @@ function configure_nfs_client_and_mount0 {
     local NFS_HOST_EXPORT_PATH=${1}   # E.g., controller-vm-ab12cd:/azlamp or 172.16.3.100:/drbd/data
     local MOUNTPOINT=${2}             # E.g., /azlamp
 
+    wait_for_apt_lock
     apt install -y nfs-common
     mkdir -p ${MOUNTPOINT}
 

--- a/scripts/install_gluster.sh
+++ b/scripts/install_gluster.sh
@@ -34,9 +34,14 @@ RAIDPARTITION="/dev/md1p1"
 # An set of disks to ignore from partitioning and formatting
 BLACKLIST="/dev/sda|/dev/sdb"
 
+#import helper functions
+. ./helper_functions.sh
+
 # make sure the system does automatic update
 # TODO: ENSURE THIS IS CONFIGURED CORRECTLY
+wait_for_apt_lock
 apt-get -y update
+wait_for_apt_lock
 apt-get -y install unattended-upgrades
 
 {
@@ -75,6 +80,7 @@ apt-get -y install unattended-upgrades
             if [ $_RET -eq 1 ];
             then 
                 echo "installing mdadm"
+                wait_for_apt_lock
                 apt-get -y -q install mdadm
             fi
             echo "Creating raid0"
@@ -188,12 +194,16 @@ apt-get -y install unattended-upgrades
             if [ ! -e /etc/apt/sources.list.d/gluster* ];
             then
                 echo "adding gluster ppa"
+                wait_for_apt_lock
                 apt-get  -y install python-software-properties
+                wait_for_apt_lock
                 apt-add-repository -y ppa:gluster/glusterfs-3.10
+                wait_for_apt_lock
                 apt-get -y update
             fi
             
             echo "installing gluster"
+            wait_for_apt_lock
             apt-get -y install glusterfs-server
             
             return

--- a/scripts/setup_nfs_ha.sh
+++ b/scripts/setup_nfs_ha.sh
@@ -20,7 +20,9 @@ MY_IP=$(hostname -i)
 
 function setup_required_packages
 {
+    wait_for_apt_lock
     apt update
+    wait_for_apt_lock
     apt -y install build-essential autoconf flex nfs-kernel-server corosync pacemaker resource-agents
 
     # Shouldn't let systemd start nfs-kernel-server (Pacemaker should do that)

--- a/scripts/setup_webserver.sh
+++ b/scripts/setup_webserver.sh
@@ -67,12 +67,15 @@ check_fileServerType_param $fileServerType
   echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $AZ_REPO main" |  tee /etc/apt/sources.list.d/azure-cli.list
 
   # add PHP-FPM repository 
+  wait_for_apt_lock
   add-apt-repository ppa:ondrej/php -y > /dev/null 2>&1
 
+  wait_for_apt_lock
   apt-get -qq -o=Dpkg::Use-Pty=0 update 
 
   # install pre-requisites including VARNISH and PHP-FPM
   export DEBIAN_FRONTEND=noninteractive
+  wait_for_apt_lock
   apt-get --yes \
     --no-install-recommends \
     -qq -o=Dpkg::Use-Pty=0 \
@@ -156,17 +159,22 @@ EOF
     # apt-get -y update
     # apt-get -y install glusterfs-client
 
+    wait_for_apt_lock
     add-apt-repository ppa:gluster/glusterfs-3.10 -y
+    wait_for_apt_lock
     apt-get -y update
+    wait_for_apt_lock
     apt-get -y -qq -o=Dpkg::Use-Pty=0 install glusterfs-client
   elif [ "$fileServerType" = "azurefiles" ]; then
     #apt-get -y install cifs-utils
+    wait_for_apt_lock
     apt-get -y -qq -o=Dpkg::Use-Pty=0 install cifs-utils
   fi
 
   # install the base stack
   # passing php versions $phpVersion
   # apt-get -y install nginx php$phpVersion php$phpVersion-fpm php$phpVersion-cli php$phpVersion-curl php$phpVersion-zip php-pear php$phpVersion-mbstring php$phpVersion-dev mcrypt php$phpVersion-soap php$phpVersion-json php$phpVersion-redis php$phpVersion-bcmath php$phpVersion-gd php$phpVersion-pgsql php$phpVersion-mysql php$phpVersion-xmlrpc php$phpVersion-intl php$phpVersion-xml php$phpVersion-bz2
+  wait_for_apt_lock
   apt-get -y install nginx php$phpVersion-fpm
 
   # MSSQL

--- a/scripts/woocommerce.sh
+++ b/scripts/woocommerce.sh
@@ -9,10 +9,14 @@ wooco_version=${3}
 wooco_dir_name=downloads.wordpress.org
 wooco_plugin_path=plugin/woocommerce
 
+#import helper functions
+. ./helper_functions.sh
+
 downloadwoocommerce(){
   wget -p ${wooco_URL} ${wooco_path}/
 }
 extractfile(){
+  wait_for_apt_lock
   sudo apt install unzip
   sudo unzip ${wooco_path}/${wooco_dir_name}/${wooco_plugin_path}.${wooco_version}.zip
   sudo cp -rf ${wooco_path}/woocommerce ${web_root}/wordpress/wp-content/plugins/

--- a/scripts/wordpress_script.sh
+++ b/scripts/wordpress_script.sh
@@ -4,6 +4,9 @@
 # It will update groups_var/all file in playbook with the user inputs dynamically
 # It will execute ansible playbook for installing WordPress in host VM (controller VM)
 
+# import helper functions
+. ./helper_functions.sh
+
 log_path=/home/${3}/var.txt
 home_path=/home/${3}
 vars_path=/home/${3}/wordpress/group_vars/all
@@ -12,8 +15,11 @@ wp_admin_password=$(</dev/urandom tr -dc _A-Z-a-z-0-9 | head -c8)
 wp_db_user_pass=$(</dev/urandom tr -dc _A-Z-a-z-0-9 | head -c8)
 
 install_ansible() {
+  wait_for_apt_lock
   sudo apt-add-repository ppa:ansible/ansible -y
+  wait_for_apt_lock
   sudo apt-get update
+  wait_for_apt_lock
   sudo apt-get install ansible -y
 }
 configure_ansible() {
@@ -24,7 +30,9 @@ configure_ansible() {
   sudo chmod 755 /etc/ansible/hosts
 }
 install_svn() {
+  wait_for_apt_lock
   sudo apt-get update -y
+  wait_for_apt_lock
   sudo apt-get install -y subversion
 }
 wordpress_install() {


### PR DESCRIPTION
Currently, VM/VMSS scripts are failing intermittently with error "E: Unable to acquire the dpkg frontend lock (/var/lib/dpkg/lock-frontend), is another process using it? [stderr]"

This happens when we try to run apt command while another command is already running. This PR adds waiting mechanism in case another apt is running.