### PR TITLE
Make deployment Az resilient

### DIFF
--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -1544,7 +1544,7 @@
             "sshUsername": "[parameters('sshUsername')]",
             "sslEnforcement": "[parameters('sslEnforcement')]",
             "storageAccountName": "[tolower(concat('abs',variables('resourceprefix')))]",
-            "storageAccountType": "[if(startsWith(parameters('storageAccountType'),'Premium_'), 'Premium_ZRS', parameters('storageAccountType'))]",
+            "storageAccountType": "[parameters('storageAccountType')]",
             "subnetAppGw": "[concat('appgw-subnet-',variables('resourceprefix'))]",
             "subnetAppGwPrefix": "[concat(variables('octets')[0], '.', variables('octets')[1], '.', string(add(int(variables('octets')[2]),6)))]",
             "subnetAppGwRange": "[concat(variables('octets')[0], '.', variables('octets')[1], '.', string(add(int(variables('octets')[2]),6)), '.0/24')]",

--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -519,7 +519,8 @@
                 "Standard_LRS",
                 "Standard_GRS",
                 "Standard_ZRS",
-                "Premium_LRS"
+                "Premium_LRS",
+                "Premium_ZRS"
             ],
             "metadata": {
                 "description": "Storage Account type. This storage account is only for the (currently disabled) Azure Files file share option"
@@ -972,17 +973,8 @@
                     "lampCommon": {
                         "value": "[variables('lampCommon')]"
                     },
-                    "lbPubIp": {
-                        "value": "[reference('networkTemplate').outputs.lbPubIp.value]"
-                    },
-                    "lbOut001PubIp": {
-                        "value": "[reference('networkTemplate').outputs.lbOut001PubIp.value]"
-                    },
-                    "lbOut002PubIp": {
-                        "value": "[reference('networkTemplate').outputs.lbOut002PubIp.value]"
-                    },
-                    "ctlrPubIp": {
-                        "value": "[reference('networkTemplate').outputs.ctlrPubIp.value]"
+                    "subnetIdFlexDb": {
+                        "value": "[reference('networkTemplate').outputs.subnetIdFlexDb.value]"
                     }
                 },
                 "templateLink": {
@@ -1273,8 +1265,6 @@
                 "enableAccelNwForOtherVmsSwitch": "[variables('lampCommon').enableAccelNwForOtherVmsSwitch]",
                 "extBeName": "[variables('lampCommon').extBeName]",
                 "extFeName": "[variables('lampCommon').extFeName]",
-                "extOutName001": "[variables('lampCommon').extOutName001]",
-                "extOutName002": "[variables('lampCommon').extOutName002]",
                 "extNatPool": "[variables('lampCommon').extNatPool]",
                 "extProbeHTTP": "[variables('lampCommon').extProbeHTTP]",
                 "extProbeHTTPS": "[variables('lampCommon').extProbeHTTPS]",
@@ -1295,11 +1285,7 @@
                 "httpsTermination": "[variables('lampCommon').httpsTermination]",
                 "lbDns": "[variables('lampCommon').lbDns]",
                 "lbName": "[variables('lampCommon').lbName]",
-                "lbOutName001": "[variables('lampCommon').lbOutName001]",
-                "lbOutName002": "[variables('lampCommon').lbOutName002]",
                 "lbPipName": "[variables('lampCommon').lbPipName]",
-                "lbOutPipName001": "[variables('lampCommon').lbOutPipName001]",
-                "lbOutPipName002": "[variables('lampCommon').lbOutPipName002]",
                 "lbSku": "[variables('lampCommon').lbSku]",
                 "lbTier": "[variables('lampCommon').lbTier]",
                 "location": "[variables('lampCommon').location]",
@@ -1387,8 +1373,8 @@
                 "vnetGatewayPublicIpResourceId": "[resourceId('Microsoft.Network/publicIPAddresses', variables('lampCommon').gatewayPublicIPName)]",
                 "loadBalancerPublicIpResourceId": "[resourceId('Microsoft.Network/publicIPAddresses', variables('lampCommon').lbPipName)]",
                 "loadBalancerOutputPublicIp": {
-                    "001OutboundPublicIpResourceId": "[resourceId('Microsoft.Network/publicIPAddresses', variables('lampCommon').lbOutPipName001)]",
-                    "002OutboundPublicIpResourceId": "[resourceId('Microsoft.Network/publicIPAddresses', variables('lampCommon').lbOutPipName002)]"
+                    "001OutboundPublicIpResourceId": "",
+                    "002OutboundPublicIpResourceId": ""
                 },
                 "appGatewayPublicIpResourceId": "[resourceId('Microsoft.Network/publicIPAddresses', variables('lampCommon').appGwPipName)]"
             }
@@ -1457,6 +1443,7 @@
             "azureBackupSwitch": "[parameters('azureBackupSwitch')]",
             "additionalScriptsUri": "[union(array(variables('scriptFileUris').commonFunctionsScriptUri), if (parameters('redisDeploySwitch'), variables('scriptFileUris').wordpressRedisSetupScript, variables('empty_array')))]",            
             "controllerVmSku": "[parameters('controllerVmSku')]",
+            "controllerVmZones": "[array('1')]",
             "customVnetId": "[parameters('customVnetId')]",
             "ctlrNicName": "[concat('controller-vm-nic-',variables('resourceprefix'))]",
             "ctlrNsgName": "[concat('controller-nsg-',variables('resourceprefix'))]",
@@ -1482,8 +1469,6 @@
             "enableAccelNwForOtherVmsSwitch": "[parameters('enableAccelNwForOtherVmsSwitch')]",
             "extBeName": "[concat('lb-backend-',variables('resourceprefix'))]",
             "extFeName": "[concat('lb-frontend-',variables('resourceprefix'))]",
-            "extOutName001": "[concat('lb-outbound001-',variables('resourceprefix'))]",
-            "extOutName002": "[concat('lb-outbound002-',variables('resourceprefix'))]",
             "extNatPool": "[concat('lb-natpool-',variables('resourceprefix'))]",
             "extProbeHTTP": "[concat('lb-probe-http-',variables('resourceprefix'))]",
             "extProbeHTTPS": "[concat('lb-probe-https-',variables('resourceprefix'))]",
@@ -1493,7 +1478,7 @@
             "fileServerType": "[parameters('fileServerType')]",
             "fileServerVmCount": 2,
             "fileServerVmSku": "[parameters('fileServerVmSku')]",
-            "azureFileShareType": "[if(equals(parameters('fileServerType'),'azurefiles'), if(equals(parameters('storageAccountType'),'Premium_LRS'),'nfs','smb'), '')]",
+            "azureFileShareType": "[if(equals(parameters('fileServerType'),'azurefiles'), if(startsWith(parameters('storageAccountType'),'Premium_'),'nfs','smb'), '')]",
             "flexDbDomainName": ".mysql.database.azure.com",
             "frontDoorFQDN": "[format('{0}.azurefd.net', concat('myLampFrontDoor', variables('resourceprefix')))]",
             "gatewayName": "[concat('vnet-gateway-',variables('resourceprefix'))]",
@@ -1508,11 +1493,7 @@
             "lbSku": "[parameters('loadBalancerSku')]",
             "lbTier": "[parameters('loadBalancerTier')]",
             "lbName": "[concat('lb-',variables('resourceprefix'))]",
-            "lbOutName001": "[concat('lb-out001-',variables('resourceprefix'))]",
-            "lbOutName002": "[concat('lb-out002-',variables('resourceprefix'))]",
             "lbPipName": "[concat('lb-pubip-',variables('resourceprefix'))]",
-            "lbOutPipName001": "[concat('lb-outpubip001-',variables('resourceprefix'))]",
-            "lbOutPipName002": "[concat('lb-outpubip002-',variables('resourceprefix'))]",
             "location": "[parameters('location')]",
             "controllerInstallScriptFilename": "setup_controller.sh",
             "lampOnAzureConfigsJsonPath": "/var/lib/cloud/instance/lamp_on_azure_configs.json",
@@ -1564,7 +1545,7 @@
             "sshUsername": "[parameters('sshUsername')]",
             "sslEnforcement": "[parameters('sslEnforcement')]",
             "storageAccountName": "[tolower(concat('abs',variables('resourceprefix')))]",
-            "storageAccountType": "[parameters('storageAccountType')]",
+            "storageAccountType": "[if(startsWith(parameters('storageAccountType'),'Premium_'), 'Premium_ZRS', parameters('storageAccountType'))]",
             "subnetAppGw": "[concat('appgw-subnet-',variables('resourceprefix'))]",
             "subnetAppGwPrefix": "[concat(variables('octets')[0], '.', variables('octets')[1], '.', string(add(int(variables('octets')[2]),6)))]",
             "subnetAppGwRange": "[concat(variables('octets')[0], '.', variables('octets')[1], '.', string(add(int(variables('octets')[2]),6)), '.0/24')]",
@@ -1578,6 +1559,9 @@
             "subnetSan": "[concat('san-subnet-',variables('resourceprefix'))]",
             "subnetSanPrefix": "[variables('subnetSanPrefix')]",
             "subnetSanRange": "[concat( variables('octets')[0], '.', variables('octets')[1], '.', string(add(int(variables('octets')[2]),2)), '.0/24')]",
+            "subnetFlexDb": "[concat('flexdb-subnet-',variables('resourceprefix'))]",
+            "subnetFlexDbPrefix": "[concat( variables('octets')[0], '.', variables('octets')[1], '.', string(add(int(variables('octets')[2]),1)))]",
+            "subnetFlexDbRange": "[concat( variables('octets')[0], '.', variables('octets')[1], '.', string(add(int(variables('octets')[2]),1)), '.0/24')]",
             "subnetWeb": "[concat('web-subnet-',variables('resourceprefix'))]",
             "subnetWebPrefix": "[concat( variables('octets')[0], '.', variables('octets')[1], '.', string(add(int(variables('octets')[2]),0)))]",
             "subnetWebRange": "[variables('subnetWebRange')]",

--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -1443,7 +1443,6 @@
             "azureBackupSwitch": "[parameters('azureBackupSwitch')]",
             "additionalScriptsUri": "[union(array(variables('scriptFileUris').commonFunctionsScriptUri), if (parameters('redisDeploySwitch'), variables('scriptFileUris').wordpressRedisSetupScript, variables('empty_array')))]",            
             "controllerVmSku": "[parameters('controllerVmSku')]",
-            "controllerVmZones": "[array('1')]",
             "customVnetId": "[parameters('customVnetId')]",
             "ctlrNicName": "[concat('controller-vm-nic-',variables('resourceprefix'))]",
             "ctlrNsgName": "[concat('controller-nsg-',variables('resourceprefix'))]",

--- a/nested/controller.json
+++ b/nested/controller.json
@@ -100,10 +100,35 @@
             }
         },
         {
+            "type": "Microsoft.Compute/disks",
+            "apiVersion": "2021-12-01",
+            "location": "[parameters('lampCommon').location]",
+            "condition": "[equals(parameters('lampCommon').fileServerType,'nfs')]",
+            "name": "[concat(variables('dataDiskNamePrefix'), copyIndex())]"
+,            "sku": {
+                "name": "[parameters('lampCommon').storageAccountType]"
+            },
+            "zones": "[if(endsWith(trim(parameters('lampCommon').storageAccountType), '_ZRS'), json('null'), variables('controllerVmZones'))]",
+            "copy": {
+                "name": "managedDiskResources",
+                "count": "[parameters('lampCommon').fileServerDiskCount]"
+            },
+            "properties": {
+                "diskSizeGB": "[parameters('lampCommon').fileServerDiskSize]",
+                "creationData": {
+                    "createOption": "Empty"
+                }
+            },
+            "tags": {
+                "displayName": "Controller data disk"
+            }
+        },
+        {
             "type": "Microsoft.Compute/virtualMachines",
             "apiVersion": "2019-07-01",
             "dependsOn": [
-                "[concat('Microsoft.Network/networkInterfaces/', parameters('lampCommon').ctlrNicName)]"
+                "[concat('Microsoft.Network/networkInterfaces/', parameters('lampCommon').ctlrNicName)]",
+                "managedDiskResources"
             ],
             "location": "[parameters('lampCommon').location]",
             "name": "[parameters('lampCommon').ctlrVmName]",
@@ -148,7 +173,7 @@
                     "dataDisks": "[take(variables('nfsDiskArray'),if(equals(parameters('lampCommon').fileServerType,'nfs'), parameters('lampCommon').fileServerDiskCount, 0))]"
                 }
             },
-            "zones": "[parameters('lampCommon').controllerVmZones]",
+            "zones": "[variables('controllerVmZones')]",
             "tags": {
                 "displayName": "Controller Virtual Machine"
             }
@@ -214,17 +239,18 @@
         "copy": [
             {
                 "name": "nfsDiskArray",
-                "count": 8,
+                "count": "[parameters('lampCommon').fileServerDiskCount]",
                 "input": {
                     "managedDisk": {
-                        "storageAccountType": "[parameters('lampCommon').storageAccountType]"
+                        "id": "[resourceId('Microsoft.Compute/disks', concat(variables('dataDiskNamePrefix'), copyIndex('nfsDiskArray')))]"
                     },
-                    "diskSizeGB": "[parameters('lampCommon').fileServerDiskSize]",
                     "lun": "[copyIndex('nfsDiskArray')]",
-                    "createOption": "Empty"
+                    "createOption": "attach"
                 }
             }
-        ]
+        ],
+        "controllerVmZones": "[array(1)]",
+        "dataDiskNamePrefix": "[concat('controller-vm-', parameters('lampCommon').resourcesPrefix, '-dataDisk-')]"
     },
     "outputs": {
         "controllerIP": {

--- a/nested/controller.json
+++ b/nested/controller.json
@@ -148,6 +148,7 @@
                     "dataDisks": "[take(variables('nfsDiskArray'),if(equals(parameters('lampCommon').fileServerType,'nfs'), parameters('lampCommon').fileServerDiskCount, 0))]"
                 }
             },
+            "zones": "[parameters('lampCommon').controllerVmZones]",
             "tags": {
                 "displayName": "Controller Virtual Machine"
             }

--- a/nested/db-mysql-flex.json
+++ b/nested/db-mysql-flex.json
@@ -63,7 +63,7 @@
                 "version": "[parameters('lampCommon').mysqlVersion]",
                 "administratorLogin": "[parameters('lampCommon').dbLogin]",
                 "administratorLoginPassword": "[parameters('lampCommon').dbLoginPassword]",
-                "sslEnforcement": "[parameters('lampCommon').sslEnforcement]",                
+                "sslEnforcement": "[parameters('lampCommon').sslEnforcement]",
                 "Network": {
                     "delegatedSubnetResourceId": "[parameters('subnetIdFlexDb')]",
                     "privateDnsZoneResourceId": "[variables('privateDnsZoneResourceId')]"

--- a/nested/db-mysql-flex.json
+++ b/nested/db-mysql-flex.json
@@ -39,14 +39,14 @@
         {
             "apiVersion": "2020-06-01",
             "type": "Microsoft.Network/privateDnsZones/virtualNetworkLinks",
-            "name": "[variables('virtualNetworkLinksName')]",
+            "name": "[concat(variables('flexDbPrivateDnsZoneName'), '/', variables('virtualNetworkLinksName'))]",
             "location": "global",
             "dependsOn": [
                 "[resourceId('Microsoft.Network/privateDnsZones', variables('flexDbPrivateDnsZoneName'))]"
             ],
             "properties": {
                 "virtualNetwork": {
-                    "id": "[parameters('subnetIdFlexDb')]"
+                    "id": "[variables('vnetId')]"
                 },
                 "registrationEnabled": false
             }
@@ -57,7 +57,7 @@
             "location": "[parameters('lampCommon').location]",
             "name": "[parameters('lampCommon').serverName]",
             "dependsOn": [
-                "[resourceId('Microsoft.Network/privateDnsZones/virtualNetworkLinks',variables('virtualNetworkLinksName'))]"
+                "[resourceId('Microsoft.Network/privateDnsZones/virtualNetworkLinks', variables('flexDbPrivateDnsZoneName'), variables('virtualNetworkLinksName'))]"
             ],
             "properties": {
                 "version": "[parameters('lampCommon').mysqlVersion]",
@@ -112,7 +112,8 @@
     "variables": {
         "flexConfigName": "[concat(parameters('lampCommon').serverName, '/', parameters('serverParameters').parameters[0].name)]",
         "flexDbPrivateDnsZoneName": "[concat(parameters('lampCommon').serverName, '.private.mysql.database.azure.com')]",
-        "virtualNetworkLinksName": "[concat(variables('flexDbPrivateDnsZoneName'), '/', uniqueString(parameters('subnetIdFlexDb')))]",
+        "vnetId": "[take(parameters('subnetIdFlexDb'), indexOf(parameters('subnetIdFlexDb'),'/subnets/'))]",
+        "virtualNetworkLinksName": "[uniqueString(variables('vnetId'))]",
         "privateDnsZoneResourceId": "[resourceId('Microsoft.Network/privateDnsZones', variables('flexDbPrivateDnsZoneName'))]",
         "documentation1": "This sub-template creates a mysql server.  It expects certain values in the 'common' datastructure.",
         "documentation10": " serverName                 - Mysql server name",

--- a/nested/db-mysql-flex.json
+++ b/nested/db-mysql-flex.json
@@ -8,41 +8,11 @@
             },
             "type": "object"
         },
-        "lbPubIp": {
+        "subnetIdFlexDb": {
             "metadata": {
-                "description": "Public IP address of the deployed load balancer"
+                "description": "Azure resource ID of the subnet where flex DB for MySQL instance is to be deligated"
             },
             "type": "string"
-        },
-        "lbOut001PubIp": {
-            "metadata": {
-                "description": "Outgoing Public IP address of the deployed load balancer"
-            },
-            "type": "string"
-        },
-        "lbOut002PubIp": {
-            "metadata": {
-                "description": "Outgoing Public IP address of the deployed load balancer"
-            },
-            "type": "string"
-        },
-        "ctlrPubIp": {
-            "metadata": {
-                "description": "Public IP address of the deployed controller VM"
-            },
-            "type": "string"
-        },
-        // "publicNetworkAccess": {
-        //     "type": "string",
-        //     "metadata": {
-        //         "description": "Value should be either Enabled or Disabled"
-        //     },
-        //     "defaultValue": "Enabled"
-
-        // },
-        "vnetData": {
-            "defaultValue": {},
-            "type": "Object"
         },
         "serverParameters": {
             "type": "Object",
@@ -57,49 +27,65 @@
             }
         }
     },
-    // "variables": {
-    // //"api": "2021-05-01",
-    // //"firewallRules": "[parameters('firewallRules').rules]",
-    // //"publicNetworkAccess": "[if(empty(parameters('vnetData')), 'Enabled', 'Disabled')]"
-    // //"vnetDataSet": "[if(empty(parameters('vnetData')), json('{ \"subnetArmResourceId\": \"\" }'), parameters('vnetData'))]",
-    // //"finalVnetData": "[json(concat('{ \"subnetArmResourceId\": \"', variables('vnetDataSet').subnetArmResourceId, '\"}'))]"
-    // },
     "resources": [
+        {
+            "apiVersion": "2018-09-01",
+            "type": "Microsoft.Network/privateDnsZones",
+            "name": "[variables('flexDbPrivateDnsZoneName')]",
+            "location": "global",
+            "tags": {},
+            "properties": {}
+        },
+        {
+            "apiVersion": "2020-06-01",
+            "type": "Microsoft.Network/privateDnsZones/virtualNetworkLinks",
+            "name": "[variables('virtualNetworkLinksName')]",
+            "location": "global",
+            "dependsOn": [
+                "[resourceId('Microsoft.Network/privateDnsZones', variables('flexDbPrivateDnsZoneName'))]"
+            ],
+            "properties": {
+                "virtualNetwork": {
+                    "id": "[parameters('subnetIdFlexDb')]"
+                },
+                "registrationEnabled": false
+            }
+        },
         {
             "apiVersion": "2021-05-01",
             "type": "Microsoft.DBforMySQL/flexibleServers",
             "location": "[parameters('lampCommon').location]",
             "name": "[parameters('lampCommon').serverName]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Network/privateDnsZones/virtualNetworkLinks',variables('virtualNetworkLinksName'))]"
+            ],
             "properties": {
                 "version": "[parameters('lampCommon').mysqlVersion]",
                 "administratorLogin": "[parameters('lampCommon').dbLogin]",
                 "administratorLoginPassword": "[parameters('lampCommon').dbLoginPassword]",
-                "sslEnforcement": "[parameters('lampCommon').sslEnforcement]",
-                // "publicNetworkAccess": "Enabled",
-                "publicNetworkAccess": "[parameters('lampCommon').publicNetworkAccess]",
-                // "Network": "[if(empty(parameters('vnetData').Network), json('null'), parameters('vnetData').Network)]",
-              "Storage": {
-                "storageSizeGB": "[parameters('lampCommon').mysqlPgresStgSizeGB]",
-                "iops": "[parameters('lampCommon').mysqlPgresStorageIops]"
-                // "Autogrow": "[parameters('storageAutogrow')]"
-              },
+                "sslEnforcement": "[parameters('lampCommon').sslEnforcement]",                
+                "Network": {
+                    "delegatedSubnetResourceId": "[parameters('subnetIdFlexDb')]",
+                    "privateDnsZoneResourceId": "[variables('privateDnsZoneResourceId')]"
+                },
+                "Storage": {
+                    "storageSizeGB": "[parameters('lampCommon').mysqlPgresStgSizeGB]",
+                    "iops": "[parameters('lampCommon').mysqlPgresStorageIops]"
+                },
                 "Backup": {
                     "backupRetentionDays": "[parameters('lampCommon').mysqlPgresBackupRetentionDays]",
-                    "geoRedundantBackup": "Enabled"
+                    "geoRedundantBackup": "Disabled"
                 },
-                //"availabilityZone": "[parameters('availabilityZone')]",
+                "availabilityZone": "",
                 "highAvailability": {
-                    "mode": "[parameters('lampCommon').mysqlPgresHighAvailabilityMode]"
-                //     "standbyAvailabilityZone": "[parameters('standbyAvailabilityZone')]"
+                    "mode": "[parameters('lampCommon').mysqlPgresHighAvailabilityMode]",
+                    "standbyAvailabilityZone": ""
                 }
-                // "dataencryption": {
-                //     "infrastructureEncryption": "[parameters('infrastructureEncryption')]"
-                // }
             },
             "sku": {
                 "name": "[parameters('lampCommon').mysqlPgresComputeSize]",
-                "tier": "[parameters('lampCommon').mysqlPgresSkuTier]"
-                //"capacity": "2"
+                "tier": "[parameters('lampCommon').mysqlPgresSkuTier]",
+                "capacity": "[parameters('lampCommon').mysqlPgresVcores]"
             },
             "resources": [
                 {
@@ -113,61 +99,6 @@
                         "value": "[parameters('serverParameters').parameters[0].value]",
                         "source": "[parameters('serverParameters').parameters[0].source]"
                     }
-                },
-                {
-                    "apiVersion": "2021-05-01",
-                    "dependsOn": [
-                        "[concat('Microsoft.DBforMySQL/flexibleServers/', parameters('lampCommon').serverName)]"
-                    ],
-                    "location": "[parameters('lampCommon').location]",
-                    "name": "[variables('firewallResourceNames').allowLoadBalancer]",
-                    "properties": {
-                        "startIpAddress": "[parameters('lbPubIp')]",
-                        "endIpAddress": "[parameters('lbPubIp')]"
-                    },
-                    "type": "firewallRules"
-                },
-                {
-                    "apiVersion": "2021-05-01",
-                    "dependsOn": [
-                        "[concat('Microsoft.DBforMySQL/flexibleServers/', parameters('lampCommon').serverName)]",
-                        "[variables('firewallResourceNames').allowLoadBalancer]"
-                    ],
-                    "location": "[parameters('lampCommon').location]",
-                    "name": "[variables('firewallResourceNames').allowLoadBalancerOut001]",
-                    "properties": {
-                        "startIpAddress": "[parameters('lbOut001PubIp')]",
-                        "endIpAddress": "[parameters('lbOut001PubIp')]"
-                    },
-                    "type": "firewallRules"
-                },
-                {
-                    "apiVersion": "2021-05-01",
-                    "dependsOn": [
-                        "[concat('Microsoft.DBforMySQL/flexibleServers/', parameters('lampCommon').serverName)]",
-                        "[variables('firewallResourceNames').allowLoadBalancerOut001]"
-                    ],
-                    "location": "[parameters('lampCommon').location]",
-                    "name": "[variables('firewallResourceNames').allowLoadBalancerOut002]",
-                    "properties": {
-                        "startIpAddress": "[parameters('lbOut002PubIp')]",
-                        "endIpAddress": "[parameters('lbOut002PubIp')]"
-                    },
-                    "type": "firewallRules"
-                },
-                {
-                    "apiVersion": "2021-05-01",
-                    "dependsOn": [
-                        "[concat('Microsoft.DBforMySQL/flexibleServers/', parameters('lampCommon').serverName)]",
-                        "[variables('firewallResourceNames').allowLoadBalancerOut002]"
-                    ],
-                    "location": "[parameters('lampCommon').location]",
-                    "name": "[variables('firewallResourceNames').allowControllerVM]",
-                    "properties": {
-                        "startIpAddress": "[parameters('ctlrPubIp')]",
-                        "endIpAddress": "[parameters('ctlrPubIp')]"
-                    },
-                    "type": "firewallRules"
                 }
             ]
         }
@@ -180,12 +111,9 @@
     },
     "variables": {
         "flexConfigName": "[concat(parameters('lampCommon').serverName, '/', parameters('serverParameters').parameters[0].name)]",
-        "firewallResourceNames": {
-            "allowControllerVM": "mysql-firewall-allow-ctlr",
-            "allowLoadBalancer": "mysql-firewall-allow-lb",
-            "allowLoadBalancerOut001": "mysql-firewall-allow-lb-out001",
-            "allowLoadBalancerOut002": "mysql-firewall-allow-lb-out002"
-        },
+        "flexDbPrivateDnsZoneName": "[concat(parameters('lampCommon').serverName, '.private.mysql.database.azure.com')]",
+        "virtualNetworkLinksName": "[concat(variables('flexDbPrivateDnsZoneName'), '/', uniqueString(parameters('subnetIdFlexDb')))]",
+        "privateDnsZoneResourceId": "[resourceId('Microsoft.Network/privateDnsZones', variables('flexDbPrivateDnsZoneName'))]",
         "documentation1": "This sub-template creates a mysql server.  It expects certain values in the 'common' datastructure.",
         "documentation10": " serverName                 - Mysql server name",
         "documentation11": " mysqlVersion               - Mysql version",

--- a/nested/network-subnets.json
+++ b/nested/network-subnets.json
@@ -33,10 +33,30 @@
         {
             "type": "Microsoft.Network/virtualNetworks/subnets",
             "apiVersion": "2019-11-01",
-            "name": "[concat(parameters('vnetName'), '/', parameters('lampCommon').subnetSan)]",
+            "name": "[concat(parameters('vnetName'), '/', parameters('lampCommon').subnetFlexDb)]",
             "location": "[parameters('lampCommon').location]",
             "dependsOn": [
                 "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('vnetName'), parameters('lampCommon').subnetWeb)]"
+            ],
+            "properties": {
+                "addressPrefix": "[parameters('lampCommon').subnetFlexDbRange]",
+                "delegations": [
+                    {
+                        "name": "Microsoft.DBforMySQL.flexibleServers",
+                        "properties": {
+                            "serviceName": "Microsoft.DBforMySQL/flexibleServers"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Microsoft.Network/virtualNetworks/subnets",
+            "apiVersion": "2019-11-01",
+            "name": "[concat(parameters('vnetName'), '/', parameters('lampCommon').subnetSan)]",
+            "location": "[parameters('lampCommon').location]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('vnetName'), parameters('lampCommon').subnetFlexDb)]"
             ],
             "properties": {
                 "addressPrefix": "[parameters('lampCommon').subnetSanRange]"

--- a/nested/network.json
+++ b/nested/network.json
@@ -150,46 +150,6 @@
             }
         },
         {
-            "condition": "[not(equals(parameters('lampCommon').httpsTermination, 'AppGw'))]",
-            "type": "Microsoft.Network/publicIPAddresses",
-            "sku": {
-                "name": "[parameters('lampCommon').lbSku]",
-                "tier": "[parameters('lampCommon').lbTier]"
-            },
-            "apiVersion": "2019-11-01",
-            "location": "[parameters('lampCommon').location]",
-            "name": "[parameters('lampCommon').lbOutPipName001]",
-            "properties": {
-                "dnsSettings": {
-                    "domainNameLabel": "[parameters('lampCommon').lbOutName001]"
-                },
-                "publicIPAllocationMethod": "Static"
-            },
-            "tags": {
-                "displayName": "Load Balancer Outbound Public IP 001"
-            }
-        },
-        {
-            "condition": "[not(equals(parameters('lampCommon').httpsTermination, 'AppGw'))]",
-            "type": "Microsoft.Network/publicIPAddresses",
-            "sku": {
-                "name": "[parameters('lampCommon').lbSku]",
-                "tier": "[parameters('lampCommon').lbTier]"
-            },
-            "apiVersion": "2019-11-01",
-            "location": "[parameters('lampCommon').location]",
-            "name": "[parameters('lampCommon').lbOutPipName002]",
-            "properties": {
-                "dnsSettings": {
-                    "domainNameLabel": "[parameters('lampCommon').lbOutName002]"
-                },
-                "publicIPAllocationMethod": "Static"
-            },
-            "tags": {
-                "displayName": "Load Balancer Outbound Public IP 002"
-            }
-        },
-        {
             "condition": "[equals(parameters('lampCommon').httpsTermination, 'AppGw')]",
             "type": "Microsoft.Network/publicIPAddresses",
             "apiVersion": "2019-11-01",
@@ -210,6 +170,10 @@
             "apiVersion": "2019-11-01",
             "location": "[parameters('lampCommon').location]",
             "name": "[parameters('lampCommon').ctlrPipName]",
+            "sku": {
+                "name": "Standard",
+                "tier": "Regional"
+            },
             "properties": {
                 "dnsSettings": {
                     "domainNameLabel": "[parameters('lampCommon').ctlrPipName]"
@@ -229,9 +193,7 @@
             },
             "apiVersion": "2019-11-01",
             "dependsOn": [
-                "[concat('Microsoft.Network/publicIPAddresses/',parameters('lampCommon').lbPipName)]",
-                "[concat('Microsoft.Network/publicIPAddresses/',parameters('lampCommon').lbOutPipName001)]",
-                "[concat('Microsoft.Network/publicIPAddresses/',parameters('lampCommon').lbOutPipName002)]"
+                "[concat('Microsoft.Network/publicIPAddresses/',parameters('lampCommon').lbPipName)]"
             ],
             "location": "[parameters('lampCommon').location]",
             "name": "[parameters('lampCommon').lbName]",
@@ -249,24 +211,7 @@
                                 "id": "[variables('lbPipID')]"
                             }
                         }
-                    },
-                    {
-                        "name": "[parameters('lampCommon').extOutName001 ]",
-                        "properties": {
-                            "publicIPAddress": {
-                                "id": "[variables('lbOutPip001ID')]"
-                            }
-                        }
-
-                    },
-                    {
-                        "name": "[parameters('lampCommon').extOutName002 ]",
-                        "properties": {
-                            "publicIPAddress": {
-                                "id": "[variables('lbOutPip002ID')]"
-                            }
-                        }
-                    }    
+                    }
                 ],
                 "loadBalancingRules": [
                     {
@@ -329,28 +274,7 @@
                     }
                 ],
                 "inboundNatRules": [],
-                "outboundRules": [
-                    {
-                        "name": "Outboundrule001",
-                        "properties": {
-                            "allocatedOutboundPorts": 12800,
-                            "protocol": "Tcp",
-                            "enableTcpReset": false,
-                            "idleTimeoutInMinutes": 5,
-                            "backendAddressPool": {
-                                "id": "[variables('extBeID')]"
-                            },
-                            "frontendIPConfigurations": [
-                                {
-                                    "id": "[variables('extOutID001')]"
-                                },
-                                {
-                                    "id": "[variables('extOutID002')]"
-                                }
-                            ]
-                        }
-                    }
-                ],
+                "outboundRules": [],
                 "inboundNatPools": []
             }
         },
@@ -391,25 +315,23 @@
         "documentation01": "This sub-template creates a virtual network with a number of subnets and then creates the load-balancer (or an Azure Application Gateway) with public IP/dns",
         "extBeID": "[concat(variables('extLbID'),'/backendAddressPools/',parameters('lampCommon').extBeName)]",
         "extFeID": "[concat(variables('extLbID'),'/frontendIPConfigurations/',parameters('lampCommon').extFeName)]",
-        "extOutID001": "[concat(variables('extLbID'),'/frontendIPConfigurations/',parameters('lampCommon').extOutName001)]",
-        "extOutID002": "[concat(variables('extLbID'),'/frontendIPConfigurations/',parameters('lampCommon').extOutName002)]",
         "extLbID": "[resourceId('Microsoft.Network/loadBalancers',parameters('lampCommon').lbName)]",
         "extProbeHTTPID": "[concat(variables('extLbID'),'/probes/',parameters('lampCommon').extProbeHTTP)]",
         "extProbeHTTPSID": "[concat(variables('extLbID'),'/probes/',parameters('lampCommon').extProbeHTTPS)]",
         "lbPipID": "[resourceId('Microsoft.Network/publicIPAddresses', parameters('lampCommon').lbPipName)]",
-        "lbOutPip001ID": "[resourceId('Microsoft.Network/publicIPAddresses', parameters('lampCommon').lbOutPipName001)]",
-        "lbOutPip002ID": "[resourceId('Microsoft.Network/publicIPAddresses', parameters('lampCommon').lbOutPipName002)]",
         "ctlrPipID": "[resourceId('Microsoft.Network/publicIPAddresses', parameters('lampCommon').ctlrPipName)]",
         "customVnetIdArr":              "[split(parameters('lampCommon').customVnetId, '/')]",
         "vnetSub":                      "[if(equals(parameters('lampCommon').customVnetId, ''), subscription().subscriptionId, variables('customVnetIdArr')[2])]",
         "vnetRg":                       "[if(equals(parameters('lampCommon').customVnetId, ''), resourceGroup().name, variables('customVnetIdArr')[4])]",
         "vnetName":                     "[if(equals(parameters('lampCommon').customVnetId, ''), parameters('lampCommon').vnetName, variables('customVnetIdArr')[8])]",
         "customVnetSubnetIdWeb":        "[concat(parameters('lampCommon').customVnetId, '/subnets/', parameters('lampCommon').subnetWeb)]",
+        "customVnetSubnetIdFlexDb":     "[concat(parameters('lampCommon').customVnetId, '/subnets/', parameters('lampCommon').subnetFlexDb)]",
         "customVnetSubnetIdSan":        "[concat(parameters('lampCommon').customVnetId, '/subnets/', parameters('lampCommon').subnetSan)]",
         "customVnetSubnetIdRedis":      "[concat(parameters('lampCommon').customVnetId, '/subnets/', parameters('lampCommon').subnetRedis)]",
         "customVnetSubnetIdGateway":    "[concat(parameters('lampCommon').customVnetId, '/subnets/', parameters('lampCommon').subnetGateway)]",
         "customVnetSubnetIdAppGw":      "[concat(parameters('lampCommon').customVnetId, '/subnets/', parameters('lampCommon').subnetAppGw)]",
         "subnetIdWeb":      "[if(equals(parameters('lampCommon').customVnetId, ''), resourceId('Microsoft.Network/virtualNetworks/subnets', variables('vnetName'), parameters('lampCommon').subnetWeb), variables('customVnetSubnetIdWeb'))]",
+        "subnetIdFlexDb":   "[if(equals(parameters('lampCommon').customVnetId, ''), resourceId('Microsoft.Network/virtualNetworks/subnets', variables('vnetName'), parameters('lampCommon').subnetFlexDb), variables('customVnetSubnetIdFlexDb'))]",
         "subnetIdSan":      "[if(equals(parameters('lampCommon').customVnetId, ''), resourceId('Microsoft.Network/virtualNetworks/subnets', variables('vnetName'), parameters('lampCommon').subnetSan), variables('customVnetSubnetIdSan'))]",
         "subnetIdRedis":    "[if(equals(parameters('lampCommon').customVnetId, ''), resourceId('Microsoft.Network/virtualNetworks/subnets', variables('vnetName'), parameters('lampCommon').subnetRedis), variables('customVnetSubnetIdRedis'))]",
         "subnetIdGateway":  "[if(equals(parameters('lampCommon').customVnetId, ''), resourceId('Microsoft.Network/virtualNetworks/subnets', variables('vnetName'), parameters('lampCommon').subnetGateway), variables('customVnetSubnetIdGateway'))]",
@@ -418,14 +340,6 @@
     "outputs": {
         "lbPubIp": {
             "value": "[if(equals(parameters('lampCommon').httpsTermination, 'AppGw'), '0.0.0.0', reference(parameters('lampCommon').lbPipName, '2017-10-01').ipAddress)]",
-            "type": "string"
-        },
-        "lbOut001PubIp": {
-            "value": "[if(equals(parameters('lampCommon').httpsTermination, 'AppGw'), '0.0.0.0', reference(parameters('lampCommon').lbOutPipName001, '2017-10-01').ipAddress)]",
-            "type": "string"
-        },
-        "lbOut002PubIp": {
-            "value": "[if(equals(parameters('lampCommon').httpsTermination, 'AppGw'), '0.0.0.0', reference(parameters('lampCommon').lbOutPipName002, '2017-10-01').ipAddress)]",
             "type": "string"
         },
         "ctlrPubIp": {
@@ -446,6 +360,10 @@
         },
         "subnetIdRedis": {
             "value": "[variables('subnetIdRedis')]",
+            "type": "string"
+        },
+        "subnetIdFlexDb": {
+            "value": "[variables('subnetIdFlexDb')]",
             "type": "string"
         }
     }

--- a/nested/premium-files-nfs.json
+++ b/nested/premium-files-nfs.json
@@ -17,7 +17,7 @@
             "name": "[variables('storageName')]",
             "kind": "FileStorage",
             "sku": {
-                "name": "[parameters('lampCommon').storageAccountType]",
+                "name": "Premium_ZRS",
                 "tier": "Premium"
             },
             "properties": {
@@ -59,7 +59,7 @@
                 "[resourceId('Microsoft.Storage/storageAccounts', variables('storageName'))]"
             ],
             "sku": {
-                "name": "[parameters('lampCommon').storageAccountType]",
+                "name": "Premium_ZRS",
                 "tier": "Premium"
             },
             "properties": {

--- a/nested/redis.json
+++ b/nested/redis.json
@@ -18,7 +18,7 @@
     "resources": [
         {
             "type": "Microsoft.Cache/Redis",
-            "apiVersion": "2019-07-01",
+            "apiVersion": "2021-06-01",
             "location": "[parameters('lampCommon').location]",
             "name": "[parameters('lampCommon').redisCacheName]",
             "properties": {
@@ -28,6 +28,7 @@
                     "family": "[parameters('lampCommon').redisSku.family]",
                     "name": "[parameters('lampCommon').redisSku.name]"
                 },
+                "redisVersion": "6",
                 "replicasPerMaster": 2,
                 "subnetId": "[parameters('subnetIdRedis')]"
             },

--- a/nested/redis.json
+++ b/nested/redis.json
@@ -28,8 +28,14 @@
                     "family": "[parameters('lampCommon').redisSku.family]",
                     "name": "[parameters('lampCommon').redisSku.name]"
                 },
+                "replicasPerMaster": 2,
                 "subnetId": "[parameters('subnetIdRedis')]"
-            }
+            },
+            "zones": [
+                "1",
+                "2",
+                "3"
+            ]
         }
     ],
     "variables": {

--- a/nested/storageAccount.json
+++ b/nested/storageAccount.json
@@ -16,7 +16,7 @@
             "apiVersion": "2019-06-01",
             "location": "[parameters('lampCommon').location]",
             "name": "[concat(parameters('lampCommon').storageAccountName, 'naf')]",
-            "kind": "Storage",
+            "kind": "StorageV2",
             "sku": {
                 "name": "[parameters('lampCommon').storageAccountType]"
             },
@@ -47,7 +47,7 @@
             "apiVersion": "2019-06-01",
             "location": "[parameters('lampCommon').location]",
             "name": "[concat(parameters('lampCommon').storageAccountName,'af')]",
-            "kind": "Storage",
+            "kind": "StorageV2",
             "sku": {
                 "name": "[parameters('lampCommon').storageAccountType]"
             },

--- a/nested/storageAccount.json
+++ b/nested/storageAccount.json
@@ -16,7 +16,7 @@
             "apiVersion": "2019-06-01",
             "location": "[parameters('lampCommon').location]",
             "name": "[concat(parameters('lampCommon').storageAccountName, 'naf')]",
-            "kind": "StorageV2",
+            "kind": "[if(equals(parameters('lampCommon').storageAccountType, 'Premium_ZRS'), 'BlockBlobStorage', 'Storage')]",
             "sku": {
                 "name": "[parameters('lampCommon').storageAccountType]"
             },
@@ -47,7 +47,7 @@
             "apiVersion": "2019-06-01",
             "location": "[parameters('lampCommon').location]",
             "name": "[concat(parameters('lampCommon').storageAccountName,'af')]",
-            "kind": "StorageV2",
+            "kind": "Storage",
             "sku": {
                 "name": "[parameters('lampCommon').storageAccountType]"
             },

--- a/nested/webvmss.json
+++ b/nested/webvmss.json
@@ -68,7 +68,7 @@
             "name": "[parameters('lampCommon').vmssdStorageAccounttName]",
             "kind": "Storage",
             "sku": {
-                "name": "Standard_LRS"
+                "name": "Standard_ZRS"
             }
         },
         {
@@ -165,6 +165,7 @@
                 "name": "[parameters('lampCommon').autoscaleVmSku]",
                 "tier": "Standard"
             },
+            "zones": ["1","2","3"],
             "tags": {
                 "displayName": "webfarm"
             }


### PR DESCRIPTION
Made following resources Zone aware and zone redundant wherever applicable
- VMSS
- Flex DB for MySQL
- Redis Cache
- File shares, VMSS monitoring storage accounts
- Controller Public IP
- Controller VM and its resources will stick to Zone 1.

Removed the public access for below PaaS resources used by WordPress and they are accessible only within the VNet boundry. This change is required to meet the security requirements of PLR item (private links)
- **File Shares Storage Account**: Accessible from only within the VMSS/Controller VM subnet.
- **Flex DB for MySQL**: Accessible from only within the vNet boundry.
- **Redis Cache**: Accessible from only within the vNet boundry.