### PR TITLE
Remove unused storage account creation logic from storage template (#83)

### DIFF
--- a/nested/storageAccount.json
+++ b/nested/storageAccount.json
@@ -11,37 +11,6 @@
     },
     "resources": [
         {
-            "condition": "[not(variables('isAzureFiles'))]",
-            "type": "Microsoft.Storage/storageAccounts",
-            "apiVersion": "2019-06-01",
-            "location": "[parameters('lampCommon').location]",
-            "name": "[concat(parameters('lampCommon').storageAccountName, 'naf')]",
-            "kind": "[if(equals(parameters('lampCommon').storageAccountType, 'Premium_ZRS'), 'BlockBlobStorage', 'Storage')]",
-            "sku": {
-                "name": "[parameters('lampCommon').storageAccountType]"
-            },
-            "properties": {
-                "encryption": {
-                    "keySource": "Microsoft.Storage",
-                    "services": {
-                        "blob": {
-                            "enabled": true
-                        },
-                        "file": {
-                            "enabled": true
-                        }
-                    }
-                },
-                "networkAcls": {
-                    "bypass": "AzureServices",
-                    "defaultAction": "Allow",
-                    "ipRules": [],
-                    "virtualNetworkRules": []
-                },
-                "supportsHttpsTrafficOnly": true
-            }
-        },
-        {
             "condition": "[and(variables('isAzureFiles'), not(variables('isAzureFilesNFS')))]",
             "type": "Microsoft.Storage/storageAccounts",
             "apiVersion": "2019-06-01",
@@ -99,12 +68,12 @@
         "documentation3": " storageAccountType - type of storage account",
         "isAzureFiles": "[equals(parameters('lampCommon').fileServerType, 'azurefiles')]",
         "isAzureFilesNFS": "[equals(parameters('lampCommon').azureFileShareType, 'nfs')]",
-        "storageName": "[concat(parameters('lampCommon').storageAccountName,if(variables('isAzureFiles'), 'af', 'naf'))]",
+        "storageName": "[concat(parameters('lampCommon').storageAccountName,'af')]",
         "storageAccountId": "[resourceId('Microsoft.Storage/storageAccounts', variables('storageName'))]"
     },
     "outputs": {
         "storageAccountKey": {
-            "value": "[if(variables('isAzureFilesNFS'), '',listKeys(variables('storageAccountId'), '2019-06-01').keys[0].value)]",
+            "value": "[if(and(variables('isAzureFiles'), not(variables('isAzureFilesNFS'))), listKeys(variables('storageAccountId'), '2019-06-01').keys[0].value, '')]",
             "type": "string"
         },
         "storageAccountName": {


### PR DESCRIPTION
* Removed the non fileshare storage account which is never used by any component

* fixed storage template ourputs to populate storage account id.