### PR TITLE
Adding property "allowBlobPublicAccess": false to nested scripts

### DIFF
--- a/nested/storageAccount.json
+++ b/nested/storageAccount.json
@@ -73,7 +73,8 @@
                         }
                     },
                     "keySource": "Microsoft.Storage"
-                }
+                },
+                "allowBlobPublicAccess": false
             }
         }    
     ],

--- a/nested/storageAccount.json
+++ b/nested/storageAccount.json
@@ -38,7 +38,8 @@
                     "ipRules": [],
                     "virtualNetworkRules": []
                 },
-                "supportsHttpsTrafficOnly": true
+                "supportsHttpsTrafficOnly": true,
+                "allowBlobPublicAccess": false
             }
         },
         {

--- a/nested/webvmss.json
+++ b/nested/webvmss.json
@@ -69,6 +69,9 @@
             "kind": "Storage",
             "sku": {
                 "name": "Standard_LRS"
+            },
+            "properties": {
+                "allowBlobPublicAccess": false
             }
         },
         {


### PR DESCRIPTION
Adding property "allowBlobPublicAccess": false to nested scripts. 

This parameter disallows anonymous blob access by default, which is a measure aimed at increasing the security of Azure resources. 

The change is made in parallel with updates to the Azure/Solution-Center repository, now referencing the Azure/LAMP repository for all nested LAMP-related scripts. Azure/Solution-Center LAMP scripts included this "allowBlobPublicAccess": false paramater, as some Azure subscription policies disallow public access to storage accounts. This change modifies the Azure/LAMP nested scripts to have the same property.